### PR TITLE
Reviews css

### DIFF
--- a/client/src/components/app/app.jsx
+++ b/client/src/components/app/app.jsx
@@ -464,7 +464,7 @@ class App extends React.Component {
       <div className='app'>
         <div className='nav'><h1>Atelier</h1></div>
         <div className='main-container'>
-          <AppSearch handlePdtChange={this.handlePdtChange}/>
+          <AppSearch productId={this.state.productId} handlePdtChange={this.handlePdtChange}/>
 
           <div className='app-container'>
             <OverviewErrorBoundary>

--- a/client/src/components/app/app.jsx
+++ b/client/src/components/app/app.jsx
@@ -113,7 +113,7 @@ class App extends React.Component {
 
   filterReviews = (criteria, isSelected) => {
     //Currently no filters applied applied.
-    if (this.state.filteredTotalReviews.length === 0) {
+    if (this.state.filteredTotalReviews.length === 0 && this.state.selectedFilters.length === 0) {
 
       let filteredSearchedTotalReviews = this.state.searchedTotalReviews.filter((review) => review.rating === criteria);
       let filteredSearchedCurrentReviewsLength = this.state.searchedCurrentReviews.length;
@@ -142,7 +142,7 @@ class App extends React.Component {
       let newFilteredReviews = this.state.totalReviews.filter((review) => review.rating === criteria);
       let unsortedFiteredTotalReviews = [...this.state.filteredTotalReviews, ...newFilteredReviews];
       let filteredTotalReviews = sortByCriteria(this.state.reviewCriteria, unsortedFiteredTotalReviews);
-      let currentReviewsLength = this.state.filteredCurrentReviews.length;
+      let currentReviewsLength = this.state.filteredCurrentReviews.length < 2 ? this.state.currentReviews.length : this.state.filteredCurrentReviews.length;
       let filteredCurrentReviews = filteredTotalReviews.slice(0, currentReviewsLength);
       let filteredNextReviews = filteredTotalReviews.slice(currentReviewsLength, currentReviewsLength + 2);
       let selectedFilters = [...this.state.selectedFilters, criteria]
@@ -150,7 +150,7 @@ class App extends React.Component {
       let newFilteredSearchedReviews = this.state.searchedTotalReviews.filter((review) => review.rating === criteria);
       let unsortedFilteredSearchedReviews = [...this.state.filteredSearchedTotalReviews, ...newFilteredSearchedReviews];
       let filteredSearchedTotalReviews = sortByCriteria(this.state.reviewCriteria, unsortedFilteredSearchedReviews);
-      let filteredSearchedCurrentReviewsLength = this.state.filteredSearchedCurrentReviews.length === 0 ? this.state.filteredCurrentReviews.length : this.state.filteredSearchedCurrentReviews.length;
+      let filteredSearchedCurrentReviewsLength = this.state.filteredSearchedCurrentReviews.length < 2 ? this.state.currentReviews.length : this.state.filteredSearchedCurrentReviews.length;
       var filteredSearchedCurrentReviews = filteredSearchedTotalReviews.slice(0, filteredSearchedCurrentReviewsLength);
       var filteredSearchedNextReviews = filteredSearchedTotalReviews.slice(filteredSearchedCurrentReviewsLength, filteredSearchedCurrentReviewsLength + 2);
 
@@ -414,7 +414,25 @@ class App extends React.Component {
 
   handlePdtChange = (id) => {
     this.setState((prevState) => ({
-      productId: id
+      productId: id,
+      searchTerm: '',
+      totalReviews: [],
+      currentReviews: [],
+      nextReviews: [],
+      filteredTotalReviews: [],
+      filteredCurrentReviews: [],
+      filteredNextReviews: [],
+      searchedTotalReviews: [],
+      searchedCurrentReviews: [],
+      searchedNextReviews: [],
+      filteredSearchedTotalReviews: [],
+      filteredSearchedCurrentReviews: [],
+      filteredSearchedNextReviews: [],
+      reviewCriteria: 'relevant',
+      selectedFilters: [],
+      removedAllFilters: false,
+      characteristics: [],
+
     }), () => console.log('state after changing pdt', this.state))
   }
 

--- a/client/src/components/app/app.jsx
+++ b/client/src/components/app/app.jsx
@@ -400,7 +400,24 @@ class App extends React.Component {
   //  update product id from related items widget
   updateProductId = (id) => {
     this.setState({
-      productId: id
+      productId: id,
+      searchTerm: '',
+      totalReviews: [],
+      currentReviews: [],
+      nextReviews: [],
+      filteredTotalReviews: [],
+      filteredCurrentReviews: [],
+      filteredNextReviews: [],
+      searchedTotalReviews: [],
+      searchedCurrentReviews: [],
+      searchedNextReviews: [],
+      filteredSearchedTotalReviews: [],
+      filteredSearchedCurrentReviews: [],
+      filteredSearchedNextReviews: [],
+      reviewCriteria: 'relevant',
+      selectedFilters: [],
+      removedAllFilters: false,
+      characteristics: [],
     });
   }
   // when product id is updated fetch new product info before render

--- a/client/src/components/appSearch/appSearch.jsx
+++ b/client/src/components/appSearch/appSearch.jsx
@@ -27,7 +27,7 @@ class AppSearch extends React.Component {
       .then((resp) => resp.json())
       .then((products) => {
         this.setState((prevState) => ({
-          products
+          products,
         }), () => console.log('state after getting all pdts', this.state))
       })
   }
@@ -36,12 +36,21 @@ class AppSearch extends React.Component {
     this.getAllPdts()
   }
 
+  componentDidUpdate (prevProps, prevState) {
+    if (prevProps.productId !== this.props.productId) {
+      this.setState((prevState) => ({
+        term: '',
+        results: []
+      }), () => console.log('state after pdt change (APP SEARCH)', this.state))
+    }
+  }
+
   render () {
     return (
       <div className='app-search'>
         <div className='input-bar'>
           <label htmlFor='app-search'> SEARCH </label>
-          <input name='app-search' id='app-search' type='search' onChange={this.handleChange}/>
+          <input name='app-search' value={this.state.term} id='app-search' type='search' onChange={this.handleChange}/>
         </div>
 
         <div className='results'>

--- a/client/src/components/relatedItems/RelatedItems.jsx
+++ b/client/src/components/relatedItems/RelatedItems.jsx
@@ -180,7 +180,7 @@ class RelatedItems extends React.Component {
           <div ref={ref_id => this.card_container = ref_id} className="card_container">
           {/* <div ref={ref_id => this.card_container = ref_id} className="cardContainer"> */}
           {/* <i class="fa fa-chevron-left"></i> */}
-          {this.state.relatedItems.map(item => <Item updateProductId={this.props.updateProductId} id={item.id} category={item.category} name={item.name} price={item.default_price} stars={item.stars} photo={item.url}/>)}
+          {this.state.relatedItems.map((item, idx) => <Item key={idx} updateProductId={this.props.updateProductId} id={item.id} category={item.category} name={item.name} price={item.default_price} stars={item.stars} photo={item.url}/>)}
             {/* <Item itemNumber={0}/>
             <Item itemNumber={1}/>
             <Item itemNumber={2}/>

--- a/client/src/components/reviews/reviews.jsx
+++ b/client/src/components/reviews/reviews.jsx
@@ -60,7 +60,7 @@ export class Reviews extends React.Component {
               noOfFilteredSearchedTotalReviews={this.props.filteredSearchedTotalReviews.length}
             />
 
-            <Search onReviewsSearch={this.props.onReviewsSearch} searchTerm={this.props.searchTerm}/>
+            <Search onReviewsSearch={this.props.onReviewsSearch} productId={this.props.productId}/>
 
             {
               this.props.searchTerm.length >=3 && this.props.selectedFilters.length > 0 ? (this.props.filteredSearchedCurrentReviews.length === 0 ? null : reviewsList) :

--- a/client/src/components/reviews/reviews.jsx
+++ b/client/src/components/reviews/reviews.jsx
@@ -60,7 +60,7 @@ export class Reviews extends React.Component {
               noOfFilteredSearchedTotalReviews={this.props.filteredSearchedTotalReviews.length}
             />
 
-            <Search onReviewsSearch={this.props.onReviewsSearch}/>
+            <Search onReviewsSearch={this.props.onReviewsSearch} searchTerm={this.props.searchTerm}/>
 
             {
               this.props.searchTerm.length >=3 && this.props.selectedFilters.length > 0 ? (this.props.filteredSearchedCurrentReviews.length === 0 ? null : reviewsList) :

--- a/client/src/components/reviews/search.jsx
+++ b/client/src/components/reviews/search.jsx
@@ -17,7 +17,7 @@ class Search extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (prevProps.searchTerm !== ''  && this.props.searchTerm === '') {
+    if (prevProps.productId !== this.props.productId) {
       this.setState((prevState) => ({
         searchTerm: ''
       }), () => console.log('reviews search component update after changing pdt', this.state))

--- a/client/src/components/reviews/search.jsx
+++ b/client/src/components/reviews/search.jsx
@@ -1,12 +1,36 @@
 import React from 'react';
 
-const Search = ({ onReviewsSearch }) => {
+class Search extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      searchTerm: ''
+    }
+  }
 
-  return (
-    <div className='reviews-search'>
-      <input type='search' name='reviews-search' id='reviews-search' placeholder='SEARCH HERE' onChange={(e) => onReviewsSearch(e.target.value)} />
-    </div>
-  );
+  handleChange = (e) => {
+    // console.log('e', e.target.value)
+    this.props.onReviewsSearch(e.target.value);
+    this.setState((prevState) => ({
+      searchTerm: e.target.value
+    }), () => this.props.onReviewsSearch(this.state.searchTerm))
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.searchTerm !== ''  && this.props.searchTerm === '') {
+      this.setState((prevState) => ({
+        searchTerm: ''
+      }), () => console.log('reviews search component update after changing pdt', this.state))
+    }
+  }
+
+  render () {
+    return (
+      <div className='reviews-search'>
+        <input type='search' value={this.state.searchTerm} name='reviews-search' id='reviews-search' placeholder='SEARCH HERE' onChange={this.handleChange} />
+      </div>
+    );
+  }
 };
 
 export default Search;


### PR DESCRIPTION
1. FIxed bugs: 
  a. If there were 0 reviews for a star rating and it was selected as a filter and then some other rating was selected, it still displayed an empty list.
  b. Default number of reviews to be displayed has been set to 2.
  c. After searching for pdts, and selecting a new pdt, the filters and search query were not being reset. 
  d. Issue "c" was also noticed when user clicked on related lists.

2. Added key prop to realted list items.
